### PR TITLE
Fix documentation example for user_name string formatting in command handler

### DIFF
--- a/llm_handler.py
+++ b/llm_handler.py
@@ -461,7 +461,7 @@ class LLMHandler:
       async def helloworld(self, event: AstrMessageEvent):
           '''这是 hello world 指令'''
           user_name = event.get_sender_name()
-          yield event.plain_result(f"Hello, {user_name}!")
+          yield event.plain_result(f"Hello, {{user_name}}!")
       
 
 - **消息发送方式**:


### PR DESCRIPTION
### Summary
This PR fixes a documentation issue in the AstrBot plugin development guide where the example for the `/helloworld` command handler demonstrated an incorrect f-string usage for `user_name`, which caused confusion and could result in broken code if copied directly.

### Details
- Updated the code example in the plugin dev guide (llm_handler.py) to use `{{user_name}}` instead of Python f-string syntax.
- Ensures generated documentation/examples do not raise name errors when plugged into code.
- No changes to any runtime logic; impact is limited to development documentation quality.